### PR TITLE
Trailing whitespace in Gruntfile.js

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function (grunt) {
   // if you'd like to modify the default grunt config, do it here
   // for example:
   // config.less = { ... }
-  
+
   // concurrent tasks. customize this instead of the multitasks for faster 
   // builds
   config.concurrent = {


### PR DESCRIPTION
Trailing whitespace is causing a fresh install to fail lint
