### PR TITLE
Freeze grunt-ember-templates to v0.4.9

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -23,7 +23,7 @@
     "grunt-svgmin": "~0.1.0",
     "grunt-concurrent": "~0.1.0",
     "matchdep": "~0.1.1",
-    "grunt-ember-templates": "~0.4.4",
+    "grunt-ember-templates": "0.4.9",
     "grunt-neuter": "git://github.com/thomasboyt/grunt-neuter.git#glob-support"
   },
   "engines": {


### PR DESCRIPTION
freeze grunt-ember-templates to v0.4.9 as the latest version supplies handlebars v1.  Handlebars templates are getting compiled w/ v1 handlebars where the version of handlebars being required by the browser is still RC6.
