### PR TITLE
Add yo peerDependencies and files restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,16 @@
     "type": "git",
     "url": "git://github.com/thomasboyt/charcoal.git"
   },
+  "files": ["app", "module"],
   "dependencies": {
     "yeoman-generator": "~0.10.3"
   },
+  "peerDependencies": {
+    "yo": ">=1.0.0-rc.1.1"
+  },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.8.0",
+    "npm": ">=1.2.10"
   },
   "licenses": [
     {


### PR DESCRIPTION
As `yo` specifies `grunt-cli` and `bower` as peerDependencies, this should allow
a `npm install -g generator-charcoal` to install all three of them globally.
Users will no longer need to install them separately prior.

This also adds `files` attribute to the `package.json`, so only needed files are
downloaded for the user.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thomasboyt/charcoal/45)

<!-- Reviewable:end -->
